### PR TITLE
fix: implement EmitSoundToClient with CS2 EmitSound_t layout

### DIFF
--- a/plugify-plugin-s2sdk.pplugin.in
+++ b/plugify-plugin-s2sdk.pplugin.in
@@ -19101,24 +19101,42 @@
     {
       "name": "EmitSoundToClient",
       "group": "Engine",
-      "description": "Emits a sound to a specific client.",
+      "description": "Emits a sound to one or more clients.",
       "funcName": "EmitSoundToClient",
       "paramTypes": [
-        {
-          "name": "playerSlot",
-          "type": "int32",
-          "ref": false,
-          "description": "The index of the player's slot."
-        },
-        {
-          "name": "sound",
-          "type": "string",
-          "ref": false,
-          "description": "The name of the sound to emit."
-        }
+    	{
+    	  "name": "entityIndex",
+    	  "type": "int32",
+    	  "ref": false,
+    	  "description": "The index of the entity that emits the sound."
+    	},
+    	{
+    	  "name": "playersSlot",
+    	  "type": "int32[]",
+    	  "ref": false,
+    	  "description": "Player slot indices that will hear the sound."
+    	},
+    	{
+    	  "name": "sound",
+    	  "type": "string",
+    	  "ref": false,
+    	  "description": "The name of the sound to emit."
+    	},
+    	{
+    	  "name": "volume",
+    	  "type": "float",
+    	  "ref": false,
+    	  "description": "The volume of the sound."
+    	},
+    	{
+    	  "name": "pitch",
+    	  "type": "float",
+    	  "ref": false,
+    	  "description": "The pitch of the sound."
+    	}
       ],
       "retType": {
-        "type": "void"
+    	"type": "void"
       }
     },
     {

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -62,7 +62,7 @@ namespace globals {
 		UNWRAP(addresses::CreateEntityByName, g_pGameConfig->GetSignature("CGameEntitySystem::CreateEntityByName"));
 		UNWRAP(addresses::DispatchSpawn, g_pGameConfig->GetSignature("CGameEntitySystem::DispatchSpawn"));
 		UNWRAP(addresses::CEntityInstance_AcceptInput, g_pGameConfig->GetSignature("CEntityInstance::AcceptInput"));
-		//TRY(addresses::CBaseEntity_EmitSoundFilter, g_pGameConfig->GetSignature("CBaseEntity::EmitSoundFilter"));
+		UNWRAP(addresses::CBaseEntity_EmitSoundFilter, g_pGameConfig->GetSignature("CBaseEntity::EmitSoundFilter"));
 		UNWRAP(addresses::CBaseEntity_SetMoveType, g_pGameConfig->GetSignature("CBaseEntity::SetMoveType"));
 
 #if defined (CS2)

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -74,7 +74,7 @@ class CPlayer_WeaponServices;
 class IEntityFindFilter;
 class IRecipientFilter;
 struct EmitSound_t;
-struct SndOpEventGuid_t;
+struct StartSoundEventInfo;
 class CEntityKeyValues;
 class CBaseModelEntity;
 class CTakeDamageInfo;
@@ -99,7 +99,7 @@ namespace addresses {
 
 	inline void (*CEntityInstance_AcceptInput)(CEntityInstance* self, const char* inputName, CEntityInstance* activator, CEntityInstance* caller, variant_t* value, int outputID, void*);
 
-	inline SndOpEventGuid_t (*CBaseEntity_EmitSoundFilter)(IRecipientFilter& filter, CEntityIndex ent, const EmitSound_t& params);
+	inline StartSoundEventInfo (FASTCALL* CBaseEntity_EmitSoundFilter)(IRecipientFilter& filter, CEntityIndex ent, const EmitSound_t& params);
 
 	inline void (*CBaseEntity_SetMoveType)(CBaseEntity* self, MoveType_t moveType, MoveCollide_t moveCollide);
 

--- a/src/core/sdk/entity/globaltypes.h
+++ b/src/core/sdk/entity/globaltypes.h
@@ -99,7 +99,43 @@ struct SndOpEventGuid_t {
 	uint64 m_hStackHash;
 };
 
-// used with EmitSound_t
+struct StartSoundEventInfo {
+	SndOpEventGuid_t m_nSndOpEventGuid;
+	int32 m_nFlags;
+	uint64 m_nRecipients;
+};
+
+struct EmitSound_t
+{
+	EmitSound_t() :
+		m_pSoundName(0),
+		m_vecSoundOrigin(),
+		m_flVolume(VOL_NORM),
+		m_flSoundTime(0.0f),
+		m_nForceGuid(0),
+		m_nPitch(PITCH_NORM),
+		m_nFlags(0)
+	{
+	}
+	const char* m_pSoundName; // 0x0
+	Vector m_vecSoundOrigin;  // 0x8
+	float m_flVolume;		  // 0x14
+	float m_flSoundTime;	  // 0x18
+private:
+	uint8_t pad_1c[0x4];
+
+public:
+	uint32_t m_nForceGuid; // 0x20
+private:
+	uint8_t pad_24[0x4];
+
+public:
+	int16_t m_nPitch; // 0x28
+	uint8_t m_nFlags; // 0x2a
+}; // Size: 0x30 (with tail padding on x64)
+
+static_assert(sizeof(EmitSound_t) == 0x30);
+
 enum gender_t : uint8 {
 	GENDER_NONE = 0x0,
 	GENDER_MALE = 0x1,
@@ -122,42 +158,6 @@ enum gender_t : uint8 {
 	GENDER_HOSPITAL_PATIENT = 0x12,
 	GENDER_BRIDE = 0x13,
 	GENDER_LAST = 0x14,
-};
-
-struct EmitSound_t {
-	EmitSound_t() : m_nChannel(0),
-					m_pSoundName(0),
-					m_flVolume(VOL_NORM),
-					m_SoundLevel(SNDLVL_NONE),
-					m_nFlags(0),
-					m_nPitch(PITCH_NORM),
-					m_pOrigin(0),
-					m_flSoundTime(0.0f),
-					m_pflSoundDuration(0),
-					m_bEmitCloseCaption(true),
-					m_bWarnOnMissingCloseCaption(false),
-					m_bWarnOnDirectWaveReference(false),
-					m_nSpeakerEntity(-1),
-					m_UtlVecSoundOrigin(),
-					m_nForceGuid(0),
-					m_SpeakerGender(GENDER_NONE) {
-	}
-	int m_nChannel;
-	const char* m_pSoundName;
-	float m_flVolume;
-	soundlevel_t m_SoundLevel;
-	int m_nFlags;
-	int m_nPitch;
-	const Vector* m_pOrigin;
-	float m_flSoundTime;
-	float* m_pflSoundDuration;
-	bool m_bEmitCloseCaption;
-	bool m_bWarnOnMissingCloseCaption;
-	bool m_bWarnOnDirectWaveReference;
-	CEntityIndex m_nSpeakerEntity;
-	CUtlVector<Vector, int, CUtlVectorMemory_Growable<Vector, int>> m_UtlVecSoundOrigin;
-	SoundEventGuid_t m_nForceGuid;
-	gender_t m_SpeakerGender;
 };
 
 /*struct GameTime_t

--- a/src/core/sdk/utils.cpp
+++ b/src/core/sdk/utils.cpp
@@ -153,14 +153,16 @@ CServerSideClientBase* utils::GetClientBySlot(CPlayerSlot slot) {
 void utils::PlaySoundToClient(CPlayerSlot player, int channel, const char* soundName, float volume, soundlevel_t soundLevel, int flags, int pitch, const Vector& origin, float soundTime) {
 	CSingleRecipientFilter filter(player.Get());
 	EmitSound_t soundParams;
-	soundParams.m_nChannel = channel;
 	soundParams.m_pSoundName = soundName;
 	soundParams.m_flVolume = volume;
-	soundParams.m_SoundLevel = soundLevel;
-	soundParams.m_nFlags = flags;
-	soundParams.m_nPitch = pitch;
-	soundParams.m_pOrigin = origin.IsValid() ? &origin : nullptr;
+	soundParams.m_nFlags = static_cast<uint8_t>(flags);
+	soundParams.m_nPitch = static_cast<int16_t>(pitch);
 	soundParams.m_flSoundTime = soundTime;
+	if (origin.IsValid()) {
+		soundParams.m_vecSoundOrigin = origin;
+	}
+	(void)channel;
+	(void)soundLevel;
 	addresses::CBaseEntity_EmitSoundFilter(filter, player.Get() + 1, soundParams);
 }
 

--- a/src/export/engine.cpp
+++ b/src/export/engine.cpp
@@ -8,6 +8,8 @@
 #include <networksystem/inetworksystem.h>
 #include <core/sdk/entity/sounds.h>
 
+#include "recipientfilter.h"
+
 PLUGIFY_WARN_PUSH()
 
 #if defined(__clang)
@@ -224,16 +226,30 @@ extern "C" PLUGIN_API void StopSound(int entityHandle, const plg::string& sound)
 }
 
 /**
- * @brief Emits a sound to a specific client.
+ * @brief Emits a sound to one or more clients.
  *
- * @param playerSlot The index of the player's slot.
+ * @param entityIndex The index of the entity that emits the sound.
+ * @param playersSlot Player slot indices that will hear the sound.
  * @param sound The name of the sound to emit.
+ * @param volume The volume of the sound (default 1.0).
+ * @param pitch The pitch of the sound (default 0).
  */
-extern "C" PLUGIN_API void EmitSoundToClient(int playerSlot, const plg::string& sound) {
-	auto controller = helpers::GetController(playerSlot);
-	if (!controller) return;
-	ParamScope params(controller);
-	Sounds{}.EmitSoundOnClient(sound.c_str(), params[0]);
+extern "C" PLUGIN_API void EmitSoundToClient(int entityIndex, const plg::vector<int>& playersSlot, const plg::string& sound, float volume = 1, float pitch = 1) {
+	if (playersSlot.size() == 0)
+		return;
+
+	CRecipientFilter filter;
+
+	for (int i = 0; i < playersSlot.size(); i++) {
+		filter.AddRecipient(playersSlot[i]);
+	}
+
+	EmitSound_t params;
+	params.m_pSoundName = sound.c_str();
+	params.m_flVolume = volume;
+	params.m_nPitch = static_cast<int16_t>(pitch);
+
+	addresses::CBaseEntity_EmitSoundFilter(filter, entityIndex, params);
 }
 
 /**


### PR DESCRIPTION
Enable CBaseEntity::EmitSoundFilter signature, update return type to StartSoundEventInfo, and align EmitSound_t with the CS2 server struct.