### PR TITLE
fix: clear queued tasks on map change

### DIFF
--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -49,6 +49,8 @@ GAME_EVENT_F(round_start) {
 }
 
 polyhook::ResultType Hook_StartupServer(polyhook::HookHandle hook, polyhook::ParametersHandle params, int count, polyhook::ReturnHandle ret, polyhook::CallbackType type) {
+	g_ServerManager.Clear();
+
 	//auto config = polyhook::GetArgument<const GameSessionConfiguration_t *>(params, 1);
 	//auto worldSession = polyhook::GetArgument<ISource2WorldSession*>(params, 2);
 	auto mapName = polyhook::GetArgument<const char*>(params, 3);

--- a/src/core/server_manager.cpp
+++ b/src/core/server_manager.cpp
@@ -50,3 +50,15 @@ void ServerManager::AddTaskForNextWorldUpdate(TaskCallback task, const plg::vect
 	m_nextWorldUpdateTasks.emplace_back(task, userData);
 }
 
+void ServerManager::Clear() {
+	{
+		std::scoped_lock lock(m_frameTasksMutex);
+		m_nextTasks.clear();
+	}
+
+	{
+		std::scoped_lock lock(m_worldUpdateMutex);
+		m_nextWorldUpdateTasks.clear();
+	}
+}
+

--- a/src/core/server_manager.hpp
+++ b/src/core/server_manager.hpp
@@ -19,6 +19,8 @@ public:
 	void OnGameFrame();
 	void OnPreWorldUpdate();
 
+	void Clear();
+
 private:
 	struct Task {
 		TaskCallback callback;


### PR DESCRIPTION
## Problem

`ServerManager` never drops its pending task queues, so anything queued through `QueueTaskForNextFrame` / `QueueTaskForNextWorldUpdate` outlives the map it was queued on and runs against the next session.

Those callbacks close over entity handles from the previous map. A stale handle can still pass `IsValidEntHandle` when its index/serial happens to line up with a fresh entity, so the task keeps going and spawns/parents entities while the new world is still coming up. Spawning in that state leaves the engine spin-waiting forever on the new entity's scene component, which hangs the main thread until the watchdog terminates the server:

```
FATAL ERROR: Watchdog timeout exceeded, exiting
```

This was traced from three watchdog minidumps. All three showed the same hung main thread stuck in the engine's entity spawn/activate spin-wait, reached through the s2sdk task queue. Two came from one server; the third came from a completely different server with a different plugin set — the common factor was s2sdk rather than any single plugin, which matches the queue being the shared piece of state that survives the transition.

## Fix

Clear both queues in `Hook_StartupServer`, so no task outlives the session that queued it.
